### PR TITLE
Support repository url ssh://git@github/:owner/:repo

### DIFF
--- a/autoload/ghpr_blame/app.vim
+++ b/autoload/ghpr_blame/app.vim
@@ -47,6 +47,9 @@ function! s:_extract_slug() dict abort
         let m = matchlist(out, printf('^https://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\)\.git\n$', host))
     endif
     if empty(m)
+        let m = matchlist(out, printf('^ssh://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\)\n$', host))
+    endif
+    if empty(m)
         return ''
     endif
     return m[1]


### PR DESCRIPTION
In my local env, `$ git --config remote.origin.url` return `ssh://git@github.com/:owner/:repo` .
But ghpr-blame doesn't support this URL style.