### PR TITLE
Allow URLs with git protocol and/or w/o ext (.git)

### DIFF
--- a/autoload/ghpr_blame/app.vim
+++ b/autoload/ghpr_blame/app.vim
@@ -42,12 +42,9 @@ let s:GHPR.git = function('s:_git')
 function! s:_extract_slug() dict abort
     let out = self.git('config', '--get', 'remote.origin.url')
     let host = escape(self.host, '.')
-    let m = matchlist(out, printf('^git@%s:\([^/]\+/[^/]\+\)\.git\n$', host))
+    let m = matchlist(out, printf('^git@%s:\([^/]\+/[^/]\+\%%(\.git\)\?\)\n$', host))
     if empty(m)
-        let m = matchlist(out, printf('^https://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\)\.git\n$', host))
-    endif
-    if empty(m)
-        let m = matchlist(out, printf('^ssh://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\)\n$', host))
+        let m = matchlist(out, printf('^\%%(git\|https\|ssh\)://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\%%(\.git\)\?\)\n$', host))
     endif
     if empty(m)
         return ''


### PR DESCRIPTION
Some git clients (go get, ghq, etc.) uses URLs w/o the extension `.git` when cloning.  git allows such URLs in spec.

> [Why do some repository URLs end in .git while others don't? - Stack Overflow](https://stackoverflow.com/questions/11068576/why-do-some-repository-urls-end-in-git-while-others-dont)

This PR enables to detect such URLs.

In addition, I added the `git` protocol as a bonus.

note: @unasuke says the ssh pattern does not allow the `.git` extension (https://github.com/rhysd/ghpr-blame.vim/pull/3#discussion_r159382709).  But I think this is acceptable in github.com at least.