### PR TITLE
Load from GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ Please generate and set an API token by below steps.
 5. Generated token is shown at the top of your tokens list
 6. Set it to `g:ghpr_github_auth_token` (Please be careful. The token is a credential)
 
+### for GitHub Enterprise
+
+You should also prepare the token to access. It should be different from the
+github.com's one, so you can supply them by a dict form of
+`g:ghpr_github_auth_token`.
+
+```vim
+let g:ghpr_github_auth_token = {
+        \ 'github.com': '123456abcdef',
+        \ 'github.your-company.com': 'abcdef123456',
+        \ }
+```
+
+In addition, you should set the API url for GHE by `g:ghpr_github_api_url`.
+
+```vim
+let g:ghpr_github_api_url = {
+        \ 'github.your-company.com': 'https://github.your-company.com/api/v3',
+        \ }
+```
+
 ## License
 
 ```

--- a/autoload/ghpr_blame/app.vim
+++ b/autoload/ghpr_blame/app.vim
@@ -126,7 +126,12 @@ function! s:_show_pr_at(line) dict abort
     let num = self.blames[idx].pr
     if !has_key(self.pr_cache, num)
         echo 'Fetching pull request #' . num . '...'
-        let pr = self.slug.fetch_pr(num)
+        try
+            let pr = self.slug.fetch_pr(num)
+        catch
+            call ghpr_blame#error(printf('Failed to fetch: %s', v:exception))
+            return
+        endtry
         let self.pr_cache[num] = pr
     else
         let pr = self.pr_cache[num]

--- a/autoload/ghpr_blame/app.vim
+++ b/autoload/ghpr_blame/app.vim
@@ -42,12 +42,9 @@ let s:GHPR.git = function('s:_git')
 function! s:_extract_slug() dict abort
     let out = self.git('config', '--get', 'remote.origin.url')
     let host = escape(self.host, '.')
-    let m = matchlist(out, printf('^git@%s:\([^/]\+/[^/]\+\)\.git\n$', host))
+    let m = matchlist(out, printf('^git@%s:\([^/]\+/[^/]\+\%%(\.git\)\?\)\n$', host))
     if empty(m)
-        let m = matchlist(out, printf('^https://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\)\.git\n$', host))
-    endif
-    if empty(m)
-        let m = matchlist(out, printf('^ssh://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\)\n$', host))
+        let m = matchlist(out, printf('^\%%(git\|https\|ssh\)://\%%([^@/]\+@\)\?%s/\([^/]\+/[^/]\+\%%(\.git\)\?\)\n$', host))
     endif
     if empty(m)
         return ''

--- a/autoload/ghpr_blame/app.vim
+++ b/autoload/ghpr_blame/app.vim
@@ -76,11 +76,12 @@ function! s:_start() dict abort
         return
     endif
 
-    let slug = self.extract_slug()
-    if !slug.is_valid
+    try
+        let slug = self.extract_slug()
+    catch
         call ghpr_blame#warn('Cannot get GitHub repository from')
         return
-    endif
+    endtry
     let self.slug = slug
 
     let blames = self.blame()

--- a/autoload/ghpr_blame/slug.vim
+++ b/autoload/ghpr_blame/slug.vim
@@ -49,8 +49,7 @@ function! s:_fetch_pr(num) dict abort
     endif
     let url = self.api_url(a:num)
     if url ==# ''
-        call g:ghpr_blame#error(printf('unknown API url for %s', self.host))
-        return {}
+        throw printf('unknown API url for %s', self.host)
     endif
     let response = s:H.request({
                 \ 'url': url,
@@ -59,8 +58,7 @@ function! s:_fetch_pr(num) dict abort
                 \ 'client': ['curl', 'wget'],
                 \ })
     if !response.success
-        call g:ghpr_blame#error(printf('API request failed with status %s: %s', response.status, response))
-        return {}
+        throw printf('API request failed with status %s: %s', response.status, response)
     endif
     return json_decode(response.content)
 endfunction

--- a/autoload/ghpr_blame/slug.vim
+++ b/autoload/ghpr_blame/slug.vim
@@ -2,7 +2,7 @@ let s:H = ghpr_blame#vital().import('Web.HTTP')
 
 let s:SLUG = {}
 function! ghpr_blame#slug#from_url(url) abort
-    let slug = s:SLUG
+    let slug = deepcopy(s:SLUG)
     let m = matchlist(a:url, '\v^git\@([^:]+):([^/]+/[^/]{-})%(\.git)?\n*$')
     if empty(m)
         let m = matchlist(a:url, '\v^%(git|https|ssh)://%([^@/]+\@)?([^/]+)/([^/]+/[^/]{-})%(\.git)?\n*$')

--- a/autoload/ghpr_blame/slug.vim
+++ b/autoload/ghpr_blame/slug.vim
@@ -1,0 +1,69 @@
+let s:H = ghpr_blame#vital().import('Web.HTTP')
+
+let s:SLUG = {}
+function! ghpr_blame#slug#from_url(url) abort
+    let slug = s:SLUG
+    let m = matchlist(a:url, '\v^git\@([^:]+):([^/]+/[^/]{-})%(\.git)?\n*$')
+    if empty(m)
+        let m = matchlist(a:url, '\v^%(git|https|ssh)://%([^@/]+\@)?([^/]+)/([^/]+/[^/]{-})%(\.git)?\n*$')
+    endif
+    if empty(m)
+      let slug.is_valid = v:false
+      return slug
+    endif
+    let slug.is_valid = v:true
+    let slug.host = m[1]
+    let slug.path = m[2]
+    return slug
+endfunction
+
+function! s:_auth_token() dict abort
+    let raw = get(g:, 'ghpr_github_auth_token', {})
+    let token = {}
+    if type(raw) == type('')
+        let token['github.com'] = raw
+    elseif type(raw) == type({})
+        let token = raw
+    endif
+    return get(token, self.host, '')
+endfunction
+let s:SLUG.auth_token = function('s:_auth_token')
+
+function! s:_api_url(num) dict abort
+    if self.host ==# 'github.com'
+        let url = 'api.github.com'
+    else
+        let api_url = get(g:, 'ghpr_github_api_url', {})
+        let url = get(api_url, self.host, '')
+        if url ==# ''
+            return ''
+        endif
+    endif
+    return printf('%s/repos/%s/pulls/%d', url, self.path, a:num)
+endfunction
+let s:SLUG.api_url = function('s:_api_url')
+
+function! s:_fetch_pr(num) dict abort
+    let headers = {'Accept': 'application/vnd.github.v3+json'}
+    let t = self.auth_token()
+    if t !=# ''
+        let headers.Authorization = 'token ' . t
+    endif
+    let url = self.api_url(a:num)
+    if url ==# ''
+        call g:ghpr_blame#error(printf('unknown API url for %s', self.host))
+        return {}
+    endif
+    let response = s:H.request({
+                \ 'url': url,
+                \ 'headers': headers,
+                \ 'method': 'GET',
+                \ 'client': ['curl', 'wget'],
+                \ })
+    if !response.success
+        call g:ghpr_blame#error(printf('API request failed with status %s: %s', response.status, response))
+        return {}
+    endif
+    return json_decode(response.content)
+endfunction
+let s:SLUG.fetch_pr = function('s:_fetch_pr')

--- a/autoload/ghpr_blame/slug.vim
+++ b/autoload/ghpr_blame/slug.vim
@@ -8,10 +8,8 @@ function! ghpr_blame#slug#from_url(url) abort
         let m = matchlist(a:url, '\v^%(git|https|ssh)://%([^@/]+\@)?([^/]+)/([^/]+/[^/]{-})%(\.git)?\n*$')
     endif
     if empty(m)
-      let slug.is_valid = v:false
-      return slug
+        throw 'Cannot detect a remote URL'
     endif
-    let slug.is_valid = v:true
     let slug.host = m[1]
     let slug.path = m[2]
     return slug


### PR DESCRIPTION
Added feature for GitHub Enterprise.  For GHE, it needs the token & the API URL, so I added `g:ghpr_github_api_url` variable.

```vim
" token for access
let g:ghpr_github_auth_token = {
      \ 'github.com': '123456',
      \ 'github.example.com': '234567',
      \ }

" If you use github.com only, the old syntax is available too.
let g:ghpr_github_auth_token = '123456'

" API URL
let g:ghpr_github_api_url = {
      \ 'github.example.com': 'https://github.example.com/api/v3',
      \ }
```

The old syntax `let g:ghpr_github_auth_token = '123456'` is still available, and it uses `https://api.github.com` automaticcaly for github.com.  So these setting are needed only by the GHE users.

If you can accept this proposal, I will add the note these options in README.

----

This PR also includes the change aboue #5, so I close that.